### PR TITLE
修正 object 类型 realField 路径 bug

### DIFF
--- a/src/plugins/main-tool-editor-type-object/index.tsx
+++ b/src/plugins/main-tool-editor-type-object/index.tsx
@@ -35,7 +35,7 @@ class MainToolEditorObject extends React.Component<Props, State> {
         <Styled.EachItem key={index}>
           {this.props.actions.ApplicationAction.loadPluginByPosition('mainToolEditorManager', {
             editors: [editor],
-            realField: this.props.realField + '.' + editor.field
+            realField: this.props.realField
           })}
         </Styled.EachItem>
       );


### PR DESCRIPTION
object 内部包裹空间会自行追加 realField
```Javascript
realField: this.props.realField + '.' + editor.field
```
以上代码会造成字段名重复追加