### PR TITLE
修复渲染默认值后拖动控件报错

### DIFF
--- a/src/gaea-editor.component.tsx
+++ b/src/gaea-editor.component.tsx
@@ -120,6 +120,7 @@ export default class GaeaEditor extends React.Component<Props, State> {
     // 根据默认值设置页面初始属性
     if (this.props.defaultValue) {
       this.stores.getStore().actions.ViewportAction.resetViewport(this.props.defaultValue);
+      this.stores.getStore().stores.ViewportStore.dragStartDataReady = true;
     }
 
     // 将 onComponentDragStart 放到 applicationStore


### PR DESCRIPTION
根据默认值渲染页面后直接拖动 viewport 里的控件
因 dragStartDataReady 为 false 报错