### PR TITLE
处理字段名为空时不追加key

### DIFF
--- a/src/plugins/main-tool-editor-manager/index.tsx
+++ b/src/plugins/main-tool-editor-manager/index.tsx
@@ -50,7 +50,7 @@ class MainToolEditorManager extends React.Component<Props, State> {
         if (typeof editor === 'string') {
           return <Styled.TabTitle key={index}>{editor}</Styled.TabTitle>;
         } else {
-          const realField = this.props.realField === '' ? editor.field : this.props.realField + '.' + editor.field;
+          const realField = this.props.realField === '' ? editor.field : this.props.realField + (editor.field === ''? '' : '.') + editor.field;
 
           let child: React.ReactNode = null;
           const isVariable = this.props.actions.ViewportAction.instanceFieldIsVariable(


### PR DESCRIPTION
```
editSetting = {
    key: 'gaea-Form',
    name: '表单模块',
    isContainer: false,
    editors: [
      {    
            field: 'inputs',
            type: 'array',
            text: '字段管理',
            data: [
              {
                field: '',
                type: 'formfield'
              }
            ]
          }
    ]
  };
```
原有key生成模式会生成 [ {"":{}} ]数据结构
修改后会生成[ {} ]数据结构