### PR TITLE
修复渲染默认值后拖动控件报错

### DIFF
--- a/src/gaea-editor.component.tsx
+++ b/src/gaea-editor.component.tsx
@@ -120,6 +120,7 @@ export default class GaeaEditor extends React.Component<Props, State> {
     // 根据默认值设置页面初始属性
     if (this.props.defaultValue) {
       this.stores.getStore().actions.ViewportAction.resetViewport(this.props.defaultValue);
+      this.stores.getStore().stores.ViewportStore.dragStartDataReady = true;
     }
 
     // 将 onComponentDragStart 放到 applicationStore


### PR DESCRIPTION
根据默认值渲染页面后直接拖动 viewport 里的控件
因 dragStartDataReady 为 false 报错
@ascoders 
场景重现：
[![Edit on CodeSandbox](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/q8j1pzyxp9)
初次加载后stores为空状态直接拖动容器内button到外部报错
Uncaught TypeError: Cannot read property 'childs' of undefined