### PR TITLE
修正 array 插件数据编辑问题

### DIFF
--- a/src/page/viewport/edit-helper/edit-helper.component.tsx
+++ b/src/page/viewport/edit-helper/edit-helper.component.tsx
@@ -143,7 +143,20 @@ class EditHelper extends React.Component<Props, State> {
       });
     }
 
-    const wrapProps: any = _.merge(
+    // 数组属性要以组件属性为基础进行合并，默认属性中多余的数据需要进行切除。
+    const arraySliceMerge = (objValue: any, srcValue: any): any => {
+      if (_.isArray(srcValue) && _.isArray(objValue)) {
+        return _.mergeWith(
+          new Array(srcValue.length).fill(undefined),
+          objValue.slice(0, srcValue.length),
+          srcValue,
+          arraySliceMerge
+        );
+      }
+    };
+
+    // 将组件属性与默认属性合并。数组类型属性需要特殊处理。
+    const wrapProps: any = _.mergeWith(
       { instanceKey: this.props.instanceKey },
       this.defaultProps,
       { ...this.instanceInfo.data.props },
@@ -151,7 +164,8 @@ class EditHelper extends React.Component<Props, State> {
         ref: (ref: React.ReactInstance) => {
           this.wrappedInstance = ref;
         }
-      }
+      },
+      arraySliceMerge
     );
 
     return React.createElement(this.componentClass, wrapProps, childs);

--- a/src/stores/application/action.ts
+++ b/src/stores/application/action.ts
@@ -184,6 +184,35 @@ export default class ApplicationAction {
     }
   }
 
+  /**
+   * 根据组件 key 获取 defaultProps 的镜像结构。为确保能正确嵌套数组的数据，数组的数据将被完整保留，其它仅保留数据结构。
+   * @param gaeaOrPreKey 组件 gaeakey 或 preGaeakey
+   */
+  public getDefaultMirrorPropsByKey(gaeaOrPreKey: string): IDefaultProps {
+    if (!this.store.componentDefaultProps.has(gaeaOrPreKey)) {
+      return null;
+    }
+
+    const rawDefaultProps = this.store.componentDefaultProps.get(gaeaOrPreKey).$raw;
+    const buildArrayMirror = (prop: any): IDefaultProps => {
+      return _.entries(prop).reduce((memo: any, [key, val]) => {
+        if (key === 'editSetting') {
+          return memo;
+        }
+
+        if (_.isArray(val)) {
+          memo[key] = val;
+        } else if (_.isObjectLike(val)) {
+          memo[key] = buildArrayMirror(val);
+        }
+
+        return memo;
+      }, {});
+    };
+
+    return buildArrayMirror(rawDefaultProps);
+  }
+
   @Action
   public setOnComponentDragStart(fn: any) {
     this.store.onComponentDragStart = fn;

--- a/src/stores/viewport/action.ts
+++ b/src/stores/viewport/action.ts
@@ -86,7 +86,8 @@ export default class ViewportAction {
     this.store.instances.set(newInstanceKey, {
       gaeaKey: params.gaeaKey,
       data: {
-        props: params.props
+        // 参数属性优先。否则从 defaultProps 中提取数据结构，以保证数组结构的数据操作。
+        props: params.props || this.applicationAction.getDefaultMirrorPropsByKey(params.gaeaKey)
       },
       childs: [],
       parentInstanceKey: params.parentInstanceKey,


### PR DESCRIPTION
与 #37 是同一个问题。当前 array 类型在编辑默认属性时，由于默认属性混合的处理方式，导致以下现象：

1. 无法删除默认属性。减少数组元素数量后，又会被 `_.mergeWith` 给还原。
2. 当存在 `[{ "title": "foo"}]` 这样的数据结构时，修改任意数据都会导致其余默认值丢失。

我的解决方式：

* 新增组件示例时，复制 defaultProps 中的数组数据到 `data` 中，保证修改操作的准确性。
* render 时，对 defaultProps 中的数组数据进行裁减。

这个问题对 `gaea-render` 也有影响。